### PR TITLE
Fix 'No 'version' key in the manifest file for custom integration 'yo…

### DIFF
--- a/custom_components/youless/manifest.json
+++ b/custom_components/youless/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://github.com/reharmsen/hass-youless-component",
   "dependencies": [],
   "codeowners": ["@reharmsen","@pdwonline","@jongsoftdev"],
-  "requirements": []
+  "requirements": [],
+  "version": "2.0.2"
 }


### PR DESCRIPTION
…uless'.

This will fix: 'As of Home Assistant 2021.6, this integration will no longer be loaded. Please report this to the maintainer of 'youless''